### PR TITLE
Pretty coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
       options { timeout(time: 10, unit: 'MINUTES') }
       parallel {
         stage('Unit Test')             { steps { sh 'make TEST_CONCRETE_BACKEND=llvm test-simple -j4' } }
+        stage('Unit Test Python')      { steps { sh 'make TEST_CONCRETE_BACKEND=llvm unittest-python' } }
         stage('Mandos Unit Test')      { steps { sh 'make TEST_CONCRETE_BACKEND=llvm mandos-test -j4' } }
         stage('Adder Contract Test')   { steps { sh 'make TEST_CONCRETE_BACKEND=llvm elrond-adder-test' } }
         stage('Lottery Contract Test') { steps { sh 'make TEST_CONCRETE_BACKEND=llvm elrond-lottery-test' } }

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ wasm-deps:
 	$(KWASM_MAKE) deps
 
 elrond-contracts:
-	cd $(ELROND_WASM_SUBMODULE) && env RUSTFLAGS="" ./build-wasm.sh
+	cd $(ELROND_WASM_SUBMODULE) && ./investigate-wasm.sh
 
 # Building Definition
 # -------------------
@@ -139,14 +139,18 @@ mandos-test: $(llvm_kompiled)
 ELROND_ADDER_SUBMODULE := $(ELROND_CONTRACT_EXAMPLES)/adder
 ELROND_ADDER_TESTS_DIR=$(ELROND_ADDER_SUBMODULE)/mandos
 elrond_adder_tests=$(ELROND_ADDER_TESTS_DIR)/adder.scen.json
-elrond-adder-test:
+
+$(ELROND_ADDER_SUBMODULE)/output/adder.wasm: $(ELROND_ADDER_SUBMODULE)/output/adder-dbg.wasm
+	cp $< $@
+
+elrond-adder-test: $(ELROND_ADDER_SUBMODULE)/output/adder.wasm
 	$(TEST_MANDOS) $(elrond_adder_tests) --coverage
 
 ELROND_LOTTERY_SUBMODULE=$(ELROND_CONTRACT_EXAMPLES)/lottery-egld
 elrond_lottery_tests=$(shell find $(ELROND_LOTTERY_SUBMODULE) -name "*.scen.json")
 
 # Fix: the tests use an outdated name for the Wasm file.
-$(ELROND_LOTTERY_SUBMODULE)/output/lottery.wasm: $(ELROND_LOTTERY_SUBMODULE)/output/lottery-egld.wasm
+$(ELROND_LOTTERY_SUBMODULE)/output/lottery.wasm: $(ELROND_LOTTERY_SUBMODULE)/output/lottery-egld-dbg.wasm
 	cp $< $@
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
         build build-llvm build-haskell                                     \
         elrond-contracts mandos-test elrond-loaded                         \
         elrond-contract-tests elrond-adder-test elrond-lottery-test        \
+        unittest-python                                                    \
         test
 
 # Settings
@@ -151,3 +152,11 @@ $(ELROND_LOTTERY_SUBMODULE)/output/lottery.wasm: $(ELROND_LOTTERY_SUBMODULE)/out
 
 elrond-lottery-test: $(ELROND_LOTTERY_SUBMODULE)/output/lottery.wasm
 	$(TEST_MANDOS) $(elrond_lottery_tests) --coverage
+
+# Unit Tests
+# ----------
+PYTHON_UNITTEST_FILES = coverage.py
+unittest-python: $(PYTHON_UNITTEST_FILES:=.unit)
+
+%.unit: %
+	python3 $<

--- a/coverage.py
+++ b/coverage.py
@@ -145,33 +145,43 @@ def insert_coverage_on_text_module(cover, imports_mod_name=None):
 
 class TestCoverage(unittest.TestCase):
 
+    def dummy_coverage(_self, covered, not_covered):
+        coverage = { 'cov' : covered , 'not_cov': not_covered, 'idx2file' : {0: 'foo', 1: 'bar'} }
+        return [coverage]
+
     def test_cover_empty(self):
-        [c, nc] = summarize_coverage([], [])
+        cov = self.dummy_coverage([], [])
+        (c, nc) = summarize_coverage(cov)
         self.assertEqual(c, nc)
-        self.assertEqual(c, set())
+        self.assertEqual(c, {})
 
     def test_cover_all(self):
         """All functions were covered in different tests."""
         covs  = [
-            [(0, 0, ""), (0, 1, ""), (0, 2, "")],
-            [(1, 0, ""), (1, 1, ""), (1, 2, "bar")]
+            (0, 0), (0, 1), (0, 2),
+            (1, 0), (1, 1), (1, 2)
         ]
         ncovs  = covs.copy()
         ncovs.reverse()
-        [c, nc] = summarize_coverage(covs, ncovs)
-        self.assertEqual(nc, set())
+        cov = self.dummy_coverage(covs, ncovs)
+        (c, nc) = summarize_coverage(cov)
+        self.assertEqual(nc, {})
 
     def test_cover_some(self):
         covs  = [
-            [(0, 0, ""), (0, 1, ""), (0, 2, "")],
-            [(1, 0, ""), (1, 1, ""), (1, 2, "bar")]
+            (0, 0), (0, 1), (0, 2),
+            (1, 0), (1, 1), (1, 2)
         ]
         ncovs  = covs.copy()
         ncovs.reverse()
-        extra = [(0, 3, "")]
+        extra_mod_idx = 0
+        extra_fun_idx = 3
+        extra = (extra_mod_idx, extra_fun_idx)
         ncovs.append(extra)
-        [c, nc] = summarize_coverage(covs, ncovs)
-        self.assertEqual(nc, set(extra))
+        cov = self.dummy_coverage(covs, ncovs)
+        extra_mod_file = cov[0]['idx2file'][extra_mod_idx]
+        (c, nc) = summarize_coverage(cov)
+        self.assertEqual(nc[extra_mod_file], [extra_fun_idx])
 
 
 if __name__ == '__main__':

--- a/coverage.py
+++ b/coverage.py
@@ -126,7 +126,6 @@ def insert_coverage_on_text_module(cover, imports_mod_name=None):
 
     res = []
     imps = cover[imports_mod_name] if imports_mod_name in cover else []
-    print(imps, imports_mod_name, cover)
     for (name, indices) in cover.items():
         try:
             wat = subprocess.check_output("wasm2wat %s" % (name), shell=True)

--- a/coverage.py
+++ b/coverage.py
@@ -1,0 +1,11 @@
+def summarize_coverage(covered, not_covered):
+    """Takes the list of covered functions over several runs, and those not
+    covered for each run. Returns coverage data for the test suite: all
+    functions that were covered at least once, and all that were never
+    covered."""
+    def merge(list_of_lists):
+        return [(int(mod), int(idx), id) for l in list_of_lists for (mod, idx, id) in l]
+    all_covered = set(merge(covered))
+    all_sometime_not_covered = set(merge(not_covered))
+    all_not_coverd = all_sometime_not_covered.difference(all_covered)
+    return (all_covered, all_not_coverd)

--- a/coverage.py
+++ b/coverage.py
@@ -1,3 +1,6 @@
+import unittest
+
+
 def summarize_coverage(covered, not_covered):
     """Takes the list of covered functions over several runs, and those not
     covered for each run. Returns coverage data for the test suite: all
@@ -9,3 +12,38 @@ def summarize_coverage(covered, not_covered):
     all_sometime_not_covered = set(merge(not_covered))
     all_not_coverd = all_sometime_not_covered.difference(all_covered)
     return (all_covered, all_not_coverd)
+
+
+class TestCoverage(unittest.TestCase):
+
+    def test_cover_empty(self):
+        [c, nc] = summarize_coverage([], [])
+        self.assertEqual(c, nc)
+        self.assertEqual(c, set())
+
+    def test_cover_all(self):
+        """All functions were covered in different tests."""
+        covs  = [
+            [(0, 0, ""), (0, 1, ""), (0, 2, "")],
+            [(1, 0, ""), (1, 1, ""), (1, 2, "bar")]
+        ]
+        ncovs  = covs.copy()
+        ncovs.reverse()
+        [c, nc] = summarize_coverage(covs, ncovs)
+        self.assertEqual(nc, set())
+
+    def test_cover_some(self):
+        covs  = [
+            [(0, 0, ""), (0, 1, ""), (0, 2, "")],
+            [(1, 0, ""), (1, 1, ""), (1, 2, "bar")]
+        ]
+        ncovs  = covs.copy()
+        ncovs.reverse()
+        extra = [(0, 3, "")]
+        ncovs.append(extra)
+        [c, nc] = summarize_coverage(covs, ncovs)
+        self.assertEqual(nc, set(extra))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/coverage.py
+++ b/coverage.py
@@ -134,7 +134,7 @@ def insert_coverage_on_text_module(cover, imports_mod_name=None):
             line_idcs = imports(lines) + funcs(lines)
             for idx in indices + imps:
                 lidx = line_idcs[idx]
-                lines[lidx] = bytes('✗', 'utf8') + lines[lidx][1:]
+                lines[lidx] = b'!' + lines[lidx][1:]
             res.append(b'\n'.join(lines))
 
         except subprocess.CalledProcessError as e:

--- a/run-elrond-tests.py
+++ b/run-elrond-tests.py
@@ -420,12 +420,12 @@ for test in tests:
     print()
     print('See %s' % tmpdir)
 
+if args.coverage:
 
-(_, not_cov) = cov.summarize_coverage(per_test_coverage, unnamed='import')
+    (_, not_cov) = cov.summarize_coverage(per_test_coverage, unnamed='import')
 
-# TODO
-print(not_cov)
-text_modules = cov.insert_coverage_on_text_module(not_cov, imports_mod_name='import')
-for module in text_modules:
-    for line in module.splitlines():
-        print(line.decode('utf8'))
+    print(not_cov)
+    text_modules = cov.insert_coverage_on_text_module(not_cov, imports_mod_name='import')
+    for module in text_modules:
+        for line in module.splitlines():
+            print(line.decode('utf8'))

--- a/run-elrond-tests.py
+++ b/run-elrond-tests.py
@@ -424,11 +424,8 @@ for test in tests:
 (_, not_cov) = cov.summarize_coverage(per_test_coverage, unnamed='import')
 
 # TODO
-for (name, idx) in not_cov.items():
-    print(name, ': ', idx)
-    try:
-        with open(name) as f:
-            pass
-    except Exception:
-        pass
-
+print(not_cov)
+text_modules = cov.insert_coverage_on_text_module(not_cov, imports_mod_name='import')
+for module in text_modules:
+    for line in module.splitlines():
+        print(line.decode('utf8'))

--- a/run-elrond-tests.py
+++ b/run-elrond-tests.py
@@ -216,7 +216,7 @@ def file_to_module_decl(filename : str):
 def wasm_file_to_module_decl(filename : str):
     # Check that file exists.
     with open(filename, 'rb') as f:
-        module = wasm2kast.wasm2kast(f)
+        module = wasm2kast.wasm2kast(f, filename)
         return module
 
 def wat_file_to_module_decl(filename : str):

--- a/run-elrond-tests.py
+++ b/run-elrond-tests.py
@@ -10,6 +10,8 @@ import tempfile
 import os
 import wasm2kast
 
+import coverage as cov
+
 from pyk.kast import KSequence, KConstant, KApply, KToken
 
 POSITIVE_COVERAGE_CELL = "COVEREDFUNCS_CELL"
@@ -422,6 +424,9 @@ def log_intermediate_state(name, config):
 
 # Main Script
 
+per_test_covered = []
+per_test_not_covered = []
+
 for test in tests:
     tmpdir = tempfile.mkdtemp(prefix="mandos_")
     print("Intermediate test outputs stored in:\n%s" % tmpdir)
@@ -440,12 +445,18 @@ for test in tests:
 
     if args.coverage:
         end_config = wasm_config #pyk.readKastTerm(os.path.join(tmpdir, test_name))
-        (covered, uncovered) = get_coverage(end_config)
+        (covered, not_covered) = get_coverage(end_config)
+        per_test_covered.append(covered)
+        per_test_not_covered.append(not_covered)
         print('Covered:')
         [ print(f) for f in covered ]
         print()
         print('Not Covered:')
-        [ print(f) for f in uncovered ]
+        [ print(f) for f in not_covered ]
 
         print()
         print('See %s' % tmpdir)
+
+(covered, not_covered) = cov.summarize_coverage(per_test_covered, per_test_not_covered)
+print(covered)
+print(not_covered)

--- a/run-elrond-tests.py
+++ b/run-elrond-tests.py
@@ -421,7 +421,6 @@ for test in tests:
     print('See %s' % tmpdir)
 
 if args.coverage:
-
     (_, not_cov) = cov.summarize_coverage(per_test_coverage, unnamed='import')
 
     print(not_cov)


### PR DESCRIPTION
Pretty-prints coverage:

The contract test targets will output a `.wat` module with crosses (✗) next to the functions which were not covered.