### PR TITLE
Deprecate bionic image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG K_COMMIT
-FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
+FROM runtimeverificationinc/kframework-k:ubuntu-focal-${K_COMMIT}
 
 RUN    apt-get update                      \
     && apt-get upgrade --yes               \


### PR DESCRIPTION
This PR removes a use of the deprecated K bionic docker image and moves the project over to focal.