### PR TITLE
Separate kompile and llvm-kompile

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -10,7 +10,7 @@ jobs:
   simple-tests:
     runs-on: [self-hosted, linux, normal]
     name: 'Simple Tests'
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -113,7 +113,7 @@ jobs:
     runs-on: [self-hosted, linux, normal]
     name: 'Custom Contract Tests'
     needs: [feature-tests]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR separates the llvm-kompile step from kompile when building for the LLVM backend. This prevents the memory usage of Java and LLC from adding up.