### PR TITLE
Change claim output format to JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,11 +276,13 @@ TEST_MANDOS := $(POETRY_RUN) mandos --definition-dir $(llvm_dir)/mandos-kompiled
 #
 # > error: package `clap_derive v4.4.0` cannot be built because it requires rustc 1.70.0 or newer,
 # > while the currently active rustc version is 1.69.0-nightly
-# 
-# To avoid this, we enforce minimal version resolution before building the contract
+# > Either upgrade to rustc 1.70.0 or newer, or use
+# > cargo update -p clap_builder@4.4.2 --precise ver
+#
+# Use a precise clap version.
 mxpy-build/%:
 	if [ ! -f "$*/Cargo.lock" ]; then \
-	    cargo generate-lockfile --manifest-path $*/Cargo.toml -Z minimal-versions ; \
+	    cargo update --manifest-path $*/Cargo.toml -p clap --precise 4.1.0 ; \
 	fi
 
 	mxpy contract build "$*" --wasm-symbols --no-wasm-opt

--- a/kmultiversx/src/kmultiversx/foundry.py
+++ b/kmultiversx/src/kmultiversx/foundry.py
@@ -264,9 +264,7 @@ def generate_claims(
             ext = 'json'
 
         output_file = output_dir / f'{endpoint}-spec.{ext}'
-
-        with open(output_file, 'w') as f:
-            f.write(txt)
+        output_file.write_text(txt)
 
 
 def generate_claim(

--- a/kmultiversx/src/kmultiversx/utils.py
+++ b/kmultiversx/src/kmultiversx/utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, TypeVar
+
+from pyk.kast.inner import KSort
+from pykwasm import wasm2kast
+
+if TYPE_CHECKING:
+    from pyk.kast.inner import KInner
+    from pyk.kast.kast import KAst
+    from pyk.ktool.krun import KRun
+
+    T = TypeVar('T')
+
+
+def kast_to_json(config: KAst) -> dict:
+    return {'format': 'KAST', 'version': config.version(), 'term': config.to_dict()}
+
+
+def kast_to_json_str(config: KAst) -> str:
+    return json.dumps(kast_to_json(config), sort_keys=True)
+
+
+def flatten(l: list[list[T]]) -> list[T]:
+    return [item for sublist in l for item in sublist]
+
+
+def load_wasm(filename: str) -> KInner:
+    with open(filename, 'rb') as f:
+        return wasm2kast.wasm2kast(f, filename)
+
+
+def krun_config(krun: KRun, conf: KInner) -> KInner:
+    conf_kore = krun.kast_to_kore(conf, sort=KSort('GeneratedTopCell'))
+    res_conf_kore = krun.run_kore_term(conf_kore, pipe_stderr=False)
+    return krun.kore_to_kast(res_conf_kore)


### PR DESCRIPTION
Currently, the claim generator outputs claims in pretty-printed format. Changed the default output format to JSON. Added an optional command line flag `-p/--pretty` to enable pretty-printing. 